### PR TITLE
Told html to show the scroll bar always

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -38,6 +38,12 @@ a:hover {
   margin: 0 auto;
   width: 960px;
 }
+html {
+height: 100%; 
+margin-bottom: 1px; 
+overflow-y: scroll;
+}
+
 #options {
   list-style: none;
   padding-left: 0px;


### PR DESCRIPTION
Hi, Thanks for writing this. In the demo page, when you switch between' About' and 'Usage' navs, the page moves 10px left. I don't know if you noticed this, but it was distracting me. So I just made a small fix in the css. 
Thanks.
