### PR TITLE
Update use of the reserved default keyword being used as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Call __pagify__ on the aforementioned div and pass in options. _The only require
 ``` js
 $('#page_holder').pagify({
     pages: ['home', 'about', 'contact'],
-    default: 'home' // The name of a page or null for an empty div
+    'default': 'home' // The name of a page or null for an empty div
 });
 ```
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@
         $('#page_holder').pagify({
           pages: ['about', 'usage', 'options'],
           animation: 'fadeIn',
-          default: 'about',
+          'default': 'about',
           cache: true
         });
       });

--- a/pagify.js
+++ b/pagify.js
@@ -13,7 +13,7 @@
   
     this.defaults = {
       pages: [],
-      default: null,
+      'default': null,
       animation: 'show',
       onChange: function (page) {},
       cache: false

--- a/pagify.js
+++ b/pagify.js
@@ -26,7 +26,7 @@
 
         // Page is selected from: passed in value, window.location, default
         if(!page) {
-          page = window.location.hash.replace('#','') || self.settings.default;
+          page = window.location.hash.replace('#','') || self.settings['default'];
         }
          
         // Load page content from cache 
@@ -50,7 +50,7 @@
 
       // Load initial page - current hash or default page
       if(window.location.hash) self.switchPage();
-      else if(self.settings.default) self.switchPage(self.settings.default);
+      else if(self.settings['default']) self.switchPage(self.settings['default']);
 
     };
 
@@ -69,3 +69,5 @@
   };
   
 })(jQuery);
+
+


### PR DESCRIPTION
I've made a change to pagify.js and related files to update the use of the default option which was causing issues on some browsers (IE, Safari Mobile). This will fix issues #6, #8 and #9.

I've also updated the readme to indicate how the default option should be set.
